### PR TITLE
docker: alpine guix 1.1.0

### DIFF
--- a/guix/Dockerfile
+++ b/guix/Dockerfile
@@ -12,8 +12,8 @@ COPY . /bitcoin
 WORKDIR /bitcoin
 
 ARG guix_download_path=ftp://ftp.gnu.org/gnu/guix/
-ARG guix_file_name=guix-binary-1.0.1.x86_64-linux.tar.xz
-ARG guix_checksum=0b254610209fab571d7f4db156324cb541af2be354e74bf5391bedc79908583b
+ARG guix_file_name=guix-binary-1.1.0.x86_64-linux.tar.xz
+ARG guix_checksum=eae0b8b4ee8ba97e7505dbb85d61ab2ce7f0195b824d3a660076248d96cdaece
 
 RUN cd /tmp \
   && wget -q -O "$guix_file_name" "${guix_download_path}/${guix_file_name}" \


### PR DESCRIPTION
Building the new image works fine. However on the first invocation of `guix pull` after starting the daemon and exec'ing into the container:
```bash
➜  core-review git:(guix_110) ✗ docker exec -it alpine-guix /bin/bash
bash-5.0# guix pull
Migrating profile generations to '/var/guix/profiles/per-user/root'...
guix pull: error: symlink: File exists: "/var/guix/profiles/per-user/root/current-guix"
```


cc @dongcarl. You probably know what's going on here?