### PR TITLE
Pin docker images by SHA

### DIFF
--- a/guix/Dockerfile
+++ b/guix/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.14
+FROM alpine:3.14@sha256:e1c082e3d3c45cccac829840a25941e679c25d438cc8412c2fa221cf1a824e6a
 
 RUN apk --no-cache --update add \
       bash \

--- a/guix/debian.Dockerfile
+++ b/guix/debian.Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye-slim
+FROM debian:bullseye-slim@sha256:dddc0f5f01db7ca3599fd8cf9821ffc4d09ec9d7d15e49019e73228ac1eee7f9
 
 RUN apt-get update && apt-get upgrade -y && apt-get install -y \
     ca-certificates \


### PR DESCRIPTION
Tags can be moved,but SHA doesn't. To have reproducible builds pinning by SHA is recommended.
https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies
