### PR TITLE
Bump `clang` version to 11 and install `libboost-dev`

### DIFF
--- a/fuzzing/README.md
+++ b/fuzzing/README.md
@@ -45,7 +45,7 @@ diff --git a/src/consensus/tx_check.cpp b/src/consensus/tx_check.cpp
 ./autogen.sh
 ./configure --prefix=/bitcoin/depends/x86_64-pc-linux-gnu \
     --enable-fuzz --with-sanitizers=fuzzer,address,undefined \
-    CC=clang-9 CXX=clang++-9
+    CC=clang-11 CXX=clang++-11
 make -j6
 ```
 

--- a/fuzzing/fuzz.dockerfile
+++ b/fuzzing/fuzz.dockerfile
@@ -5,13 +5,14 @@ RUN apt-get update && apt-get upgrade -y && apt-get install --no-install-recomme
 	bsdmainutils \
 	bzip2 \
 	ca-certificates \
-	clang-9 \
+	clang-11 \
 	curl \
 	gcc \
 	g++ \
 	git \
 	lbzip2 \
 	libtool \
+	libboost-dev \
 	make \
 	pkg-config \
 	vim


### PR DESCRIPTION
Thank you @fanquake for this scripts.


I was having issues running the fuzzing commands
```terminal
./configure --prefix=/bitcoin/depends/x86_64-pc-linux-gnu \
    --enable-fuzz --with-sanitizers=fuzzer,address,undefined \
    CC=clang-9 CXX=clang++-9
```
emits the following error
```
checking dependency style of clang++-9... gcc3
checking whether clang++-9 supports C++20 features with -std=c++20... no
checking whether clang++-9 supports C++20 features with +std=c++20... no
checking whether clang++-9 supports C++20 features with -h std=c++20... no
configure: error: *** A compiler with support for C++20 language features is required.
```

commands below Fixed the error
```
apt install clang
./configure --prefix=/bitcoin/depends/x86_64-pc-linux-gnu \
    --enable-fuzz --with-sanitizers=fuzzer,address,undefined \
    CC=clang-11 CXX=clang++-11
```

 So bump to clang 11 and also require installing `libboost-dev` its also a dependency